### PR TITLE
Fix validation dataset path and numeric output

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,8 @@ def get_train_dataset(root_dir):
     return ImageFolder(os.path.join(root_dir, 'train'), transform=data_transforms['train'])
 
 def get_val_dataset(root_dir):
-    return ImageFolder(os.path.join(root_dir, 'test'), transform=data_transforms['test'])
+    """Validation set shares the same structure as ``train``."""
+    return ImageFolder(os.path.join(root_dir, 'val'), transform=data_transforms['test'])
 
 # 测试集：无标签，仅返回图像和文件名
 class TestDataset(Dataset):

--- a/main.py
+++ b/main.py
@@ -21,7 +21,8 @@ def predict(model, loader, device):
 
 # 保存结果到 CSV
 def save_results(ids, preds, class_names, out_file):
-    labels = [class_names[p] for p in preds]
+    """Write numeric class ids starting from 1."""
+    labels = [p + 1 for p in preds]
     df = pd.DataFrame({'id': ids, 'label': labels})
     df.to_csv(out_file, index=False)
 


### PR DESCRIPTION
## Summary
- load validation data from `val/` rather than `test/`
- save predictions as numeric class ids in `main.py`

## Testing
- `python -m py_compile main.py train.py config.py model.py`

------
https://chatgpt.com/codex/tasks/task_e_686238cf4fd08322ab55e100b66c2454