### PR TITLE
Update CSV output format

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,4 +45,5 @@ class TestDataset(Dataset):
         fname = self.names[idx]
         path = os.path.join(self.root, fname)
         img = Image.open(path).convert('RGB')
-        return self.transform(img), os.path.splitext(fname)[0]
+        # return the file name with extension for saving results
+        return self.transform(img), fname

--- a/main.py
+++ b/main.py
@@ -22,10 +22,13 @@ def predict(model, loader, device):
 
 # 保存结果到 CSV
 def save_results(ids, preds, class_names, out_file):
-    """Write numeric class ids starting from 1."""
-    labels = [p + 1 for p in preds]
+    """Write predicted class names padded to four digits."""
+    labels = []
+    for p in preds:
+        name = class_names[p]
+        labels.append(str(name).zfill(4))
     df = pd.DataFrame({'id': ids, 'label': labels})
-    df.to_csv(out_file, index=False)
+    df.to_csv(out_file, index=False, header=False)
 
 # 主推理脚本
 def main():


### PR DESCRIPTION
## Summary
- return file names with extension from `TestDataset`
- zero-pad predicted class names in `save_results` and drop CSV header

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68629328680c83228399aa26ac77d3d4