### PR TITLE
Handle truncated images

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 # config.py
 import os
-from PIL import Image
+from PIL import Image, ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 import torch
 from torch.utils.data import Dataset
 from torchvision import transforms


### PR DESCRIPTION
## Summary
- enable loading truncated images to avoid OSError during training

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68629d434e0083228d6c28f7607f844a