### PR TITLE
Enhance backbone with CBAM and lightweight RPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 本项目实现细粒度网络监督多分类任务，模型基于 EfficientNet 架构并结合 Transformer 编码器。
 
-整体流程：EfficientNet Backbone 提取特征后接 SEBlock，然后将特征展平并加入位置编码送入 Transformer Encoder，最后进行分类。
+整体流程：EfficientNet Backbone 提取特征后，依次加入 SEBlock、CBAM 以及轻量级 RPN，
+在自动聚焦局部判别区域的同时抽取候选部件特征。然后将全局特征展平并加入位置编码送入
+更深的 Transformer Encoder，融合局部候选特征后进行分类。
 
 ## 环境要求
 - Python 3.10
@@ -18,6 +20,9 @@
 ```bash
 python train.py --root path/to/dataset --device cuda
 ```
+
+若数据集中包含带 alpha 通道的 RGBA 图像，数据加载器会自动转为 RGB，避免训练时的
+相关警告。
 
 ### 预测
 `main.py` 用于加载训练好的权重并对测试集进行预测：

--- a/config.py
+++ b/config.py
@@ -7,6 +7,13 @@ from torch.utils.data import Dataset
 from torchvision import transforms
 from torchvision.datasets import ImageFolder
 
+# Custom loader to handle RGBA images by converting them to RGB. This avoids
+# warnings during training when images contain an alpha channel.
+def rgb_loader(path):
+    with open(path, 'rb') as f:
+        img = Image.open(f)
+        return img.convert('RGB')
+
 _train_subset = None
 _val_subset = None
 
@@ -34,7 +41,7 @@ def _prepare_datasets(root_dir):
         return
 
     base_dir = os.path.join(root_dir, 'train')
-    full_dataset = ImageFolder(base_dir)
+    full_dataset = ImageFolder(base_dir, loader=rgb_loader)
     n_total = len(full_dataset)
     val_len = int(n_total * 0.2)
     train_len = n_total - val_len
@@ -43,8 +50,8 @@ def _prepare_datasets(root_dir):
     train_indices = indices[:train_len]
     val_indices = indices[train_len:]
 
-    train_set = ImageFolder(base_dir, transform=data_transforms['train'])
-    val_set = ImageFolder(base_dir, transform=data_transforms['test'])
+    train_set = ImageFolder(base_dir, transform=data_transforms['train'], loader=rgb_loader)
+    val_set = ImageFolder(base_dir, transform=data_transforms['test'], loader=rgb_loader)
     _train_subset = ImageFolderSubset(train_set, train_indices)
     _val_subset = ImageFolderSubset(val_set, val_indices)
 

--- a/model.py
+++ b/model.py
@@ -2,6 +2,7 @@
 from efficientnet_pytorch import EfficientNet
 import torch
 import torch.nn as nn
+from torchvision.ops import roi_align
 
 
 class PositionalEncoding(nn.Module):
@@ -42,14 +43,115 @@ class SEBlock(nn.Module):
         y = self.fc(y).view(b, c, 1, 1)
         return x * y
 
+
+class ChannelAttention(nn.Module):
+    """Channel attention used in CBAM."""
+
+    def __init__(self, channels: int, reduction: int = 16) -> None:
+        super().__init__()
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.max_pool = nn.AdaptiveMaxPool2d(1)
+        self.fc = nn.Sequential(
+            nn.Conv2d(channels, channels // reduction, kernel_size=1, bias=False),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(channels // reduction, channels, kernel_size=1, bias=False)
+        )
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        avg_out = self.fc(self.avg_pool(x))
+        max_out = self.fc(self.max_pool(x))
+        out = avg_out + max_out
+        return self.sigmoid(out)
+
+
+class SpatialAttention(nn.Module):
+    """Spatial attention used in CBAM."""
+
+    def __init__(self, kernel_size: int = 7) -> None:
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv = nn.Conv2d(2, 1, kernel_size, padding=padding, bias=False)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        avg_out = torch.mean(x, dim=1, keepdim=True)
+        max_out, _ = torch.max(x, dim=1, keepdim=True)
+        x = torch.cat([avg_out, max_out], dim=1)
+        x = self.conv(x)
+        return self.sigmoid(x)
+
+
+class CBAM(nn.Module):
+    """Convolutional Block Attention Module."""
+
+    def __init__(self, channels: int, reduction: int = 16) -> None:
+        super().__init__()
+        self.channel = ChannelAttention(channels, reduction)
+        self.spatial = SpatialAttention()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = x * self.channel(x)
+        out = out * self.spatial(out)
+        return out
+
+
+class LightweightRPN(nn.Module):
+    """Simplified RPN generating rough region proposals."""
+
+    def __init__(self, channels: int, num_proposals: int = 4, roi_size: int = 7) -> None:
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(channels, channels // 2, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+        )
+        self.box_pred = nn.Conv2d(channels // 2, num_proposals * 4, kernel_size=1)
+        self.part_head = nn.Sequential(
+            nn.Conv2d(channels, channels, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d(1),
+        )
+        self.num_proposals = num_proposals
+        self.roi_size = roi_size
+
+    def forward(self, feat: torch.Tensor) -> torch.Tensor:
+        b, c, h, w = feat.shape
+        x = self.conv(feat)
+        box = self.box_pred(x)
+        box = torch.sigmoid(nn.functional.adaptive_avg_pool2d(box, 1))
+        box = box.view(b, self.num_proposals, 4)
+
+        # scale to feature map size
+        boxes = box.clone()
+        boxes[..., [0, 2]] *= w
+        boxes[..., [1, 3]] *= h
+
+        # format boxes for roi_align
+        boxes_formatted = []
+        for i in range(b):
+            for j in range(self.num_proposals):
+                coord = torch.tensor([i, boxes[i, j, 0], boxes[i, j, 1], boxes[i, j, 2], boxes[i, j, 3]], device=feat.device)
+                boxes_formatted.append(coord)
+        boxes_formatted = torch.stack(boxes_formatted)
+
+        roi_feats = roi_align(feat, boxes_formatted, output_size=self.roi_size)
+        roi_feats = self.part_head(roi_feats)
+        roi_feats = roi_feats.view(b, self.num_proposals, c)
+        # aggregate proposals
+        local_feat = roi_feats.mean(dim=1)
+        return local_feat
+
 class AIModel(nn.Module):
     def __init__(self, arch: str = 'efficientnet-b2', num_classes: int = 400,
-                 embed_dim: int = 256, num_layers: int = 2, num_heads: int = 8) -> None:
+                 embed_dim: int = 256, num_layers: int = 4, num_heads: int = 8,
+                 num_proposals: int = 4) -> None:
         super().__init__()
         # ImageNet-1k 预训练
         self.backbone = EfficientNet.from_pretrained(arch)
-        # Attention module after feature extraction
+        # Attention modules
         self.attention = SEBlock(self.backbone._conv_head.out_channels)
+        self.cbam = CBAM(self.backbone._conv_head.out_channels)
+        self.rpn = LightweightRPN(self.backbone._conv_head.out_channels, num_proposals=num_proposals)
 
         self.embed_conv = nn.Conv2d(
             self.backbone._conv_head.out_channels, embed_dim, kernel_size=1
@@ -60,14 +162,21 @@ class AIModel(nn.Module):
         )
         self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
 
+        self.local_fc = nn.Linear(self.backbone._conv_head.out_channels, embed_dim)
+
         self.pool = nn.AdaptiveAvgPool1d(1)
         self.dropout = self.backbone._dropout
         self.classifier = nn.Linear(embed_dim, num_classes)
 
     def forward(self, x):
-        # Backbone feature extraction with attention
+        # Backbone feature extraction with attention modules
         x = self.backbone.extract_features(x)
         x = self.attention(x)
+        x = self.cbam(x)
+
+        # Local region proposals and features
+        local_feat = self.rpn(x)
+        local_feat = self.local_fc(local_feat)
 
         # Flatten spatial dims and add positional information
         x = self.embed_conv(x)
@@ -78,9 +187,12 @@ class AIModel(nn.Module):
         # Transformer encoder
         x = self.transformer(x)
 
-        # Pool and classify
+        # Pool global features
         x = x.transpose(1, 2)  # (b, c, h*w)
-        x = self.pool(x).squeeze(-1)
-        x = self.dropout(x)
-        x = self.classifier(x)
-        return x
+        global_feat = self.pool(x).squeeze(-1)
+        global_feat = self.dropout(global_feat)
+
+        # Fuse global and local features
+        feat = global_feat + local_feat
+        out = self.classifier(feat)
+        return out


### PR DESCRIPTION
## Summary
- convert RGBA images to RGB when loading datasets to avoid warnings
- introduce CBAM and lightweight RPN modules after EfficientNet
- raise Transformer depth to four layers and fuse local/global features
- document new pipeline and RGBA handling in README

## Testing
- `python -m py_compile *.py`
- `python train.py --help`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686381e831c883229e7ca477bfc232b7