### PR TITLE
Add training progress and attention visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 ```bash
 python train.py --root path/to/dataset --device cuda
 ```
+可选使用 `--logdir` 将指标写入 TensorBoard：
+```bash
+python train.py --root path/to/dataset --logdir runs
+```
 
 若数据集中包含带 alpha 通道的 RGBA 图像，数据加载器会自动转为 RGB，避免训练时的
 相关警告。
@@ -29,4 +33,8 @@ python train.py --root path/to/dataset --device cuda
 ```bash
 python main.py --root path/to/dataset --weights model/model.pth --device cuda
 ```
+
+### 可视化
+- `visualize_cam.py` 使用 Grad-CAM 查看注意力区域
+- `visualize_proposals.py` 绘制前 K 个候选框
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ torchvision==0.22.1+cu126
 tqdm
 pandas
 efficientnet_pytorch
-
+matplotlib
+opencv-python

--- a/visualize_cam.py
+++ b/visualize_cam.py
@@ -3,8 +3,9 @@ import torch
 from PIL import Image
 from model import AIModel
 from config import data_transforms
-import matplotlib.pyplot as plt
 import numpy as np
+import os
+import cv2
 
 class GradCAM:
     def __init__(self, model, target_layer):
@@ -23,47 +24,90 @@ class GradCAM:
 
     def __call__(self, input_tensor, class_idx=None):
         self.model.zero_grad()
-        output = self.model(input_tensor)
-        if class_idx is None:
-            class_idx = output.argmax(dim=1).item()
-        loss = output[:, class_idx].sum()
-        loss.backward()
+
+        # 显式启用梯度追踪（即使在 no_grad 外层环境中）
+        with torch.enable_grad():
+            input_tensor.requires_grad = True
+            output = self.model(input_tensor)
+
+            if class_idx is None:
+                class_idx = output.argmax(dim=1).item()
+            loss = output[:, class_idx].sum()
+            loss.backward()
+
         weights = self.gradients.mean(dim=(2, 3), keepdim=True)
         cam = (weights * self.activations).sum(dim=1)
         cam = torch.relu(cam)
-        cam = torch.nn.functional.interpolate(cam.unsqueeze(1), size=input_tensor.shape[-2:], mode='bilinear', align_corners=False)
+        cam = torch.nn.functional.interpolate(
+            cam.unsqueeze(1),
+            size=input_tensor.shape[-2:],
+            mode='bilinear',
+            align_corners=False
+        )
         cam = cam.squeeze().cpu().numpy()
         cam = (cam - cam.min()) / (cam.max() - cam.min() + 1e-8)
         return cam
 
-def overlay_cam(img, cam, out_file):
-    plt.figure(figsize=(6, 6))
-    plt.imshow(img)
-    plt.imshow(cam, cmap='jet', alpha=0.5)
-    plt.axis('off')
-    plt.tight_layout()
-    plt.savefig(out_file)
-    plt.close()
 
+def overlay_cam(img, cam, out_path, threshold=0.6):
+    if isinstance(img, Image.Image):
+        img = np.array(img)
+
+    h, w, _ = img.shape
+    cam_resized = cv2.resize(cam, (w, h))
+    cam_uint8 = np.uint8(255 * cam_resized)
+
+    heatmap = cv2.applyColorMap(cam_uint8, cv2.COLORMAP_JET)
+    heatmap = cv2.cvtColor(heatmap, cv2.COLOR_BGR2RGB)
+
+    mask = cam_resized > threshold
+    mask = mask.astype(np.uint8)
+    mask = np.expand_dims(mask, axis=-1)
+
+    overlay = img.astype(np.float32)
+    heatmap = heatmap.astype(np.float32)
+    overlay = overlay * (1 - mask * 0.5) + heatmap * (mask * 0.5)
+    overlay = np.clip(overlay, 0, 255).astype(np.uint8)
+
+    Image.fromarray(overlay).save(out_path)
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--image', required=True, help='path to image')
+    parser.add_argument('--input_dir', default='data/WebFG-400/train/000', help='input image folder')
+    parser.add_argument('--output_dir', default='data/outputs_cam', help='output image folder')
     parser.add_argument('--weights', default='model/model.pth', help='model weights')
     parser.add_argument('--device', default='cuda' if torch.cuda.is_available() else 'cpu')
     args = parser.parse_args()
 
+    os.makedirs(args.output_dir, exist_ok=True)
+
     device = torch.device(args.device)
     model = AIModel('efficientnet-b2', num_classes=400).to(device)
     model.load_state_dict(torch.load(args.weights, map_location=device))
+    model.eval()
+
     cam_extractor = GradCAM(model, model.cbam)
 
-    img = Image.open(args.image).convert('RGB')
-    transform = data_transforms['test']
-    tensor = transform(img).unsqueeze(0).to(device)
+    for filename in os.listdir(args.input_dir):
+        if not filename.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp')):
+            continue
 
-    cam = cam_extractor(tensor)
-    overlay_cam(np.array(img), cam, 'grad_cam.png')
+        img_path = os.path.join(args.input_dir, filename)
+        out_path = os.path.join(args.output_dir, filename)
+
+        try:
+            img = Image.open(img_path).convert('RGB')
+        except Exception as e:
+            print(f"Failed to load {img_path}: {e}")
+            continue
+
+        tensor = data_transforms['test'](img).unsqueeze(0).to(device)
+
+        with torch.no_grad():
+            cam = cam_extractor(tensor)
+
+        overlay_cam(img, cam, out_path)
+        print(f"Saved: {out_path}")
 
 if __name__ == '__main__':
     main()

--- a/visualize_cam.py
+++ b/visualize_cam.py
@@ -1,0 +1,69 @@
+import argparse
+import torch
+from PIL import Image
+from model import AIModel
+from config import data_transforms
+import matplotlib.pyplot as plt
+import numpy as np
+
+class GradCAM:
+    def __init__(self, model, target_layer):
+        self.model = model
+        self.target_layer = target_layer
+        self.activations = None
+        self.gradients = None
+        target_layer.register_forward_hook(self.save_activation)
+        target_layer.register_full_backward_hook(self.save_gradient)
+
+    def save_activation(self, module, inp, out):
+        self.activations = out.detach()
+
+    def save_gradient(self, module, grad_input, grad_output):
+        self.gradients = grad_output[0].detach()
+
+    def __call__(self, input_tensor, class_idx=None):
+        self.model.zero_grad()
+        output = self.model(input_tensor)
+        if class_idx is None:
+            class_idx = output.argmax(dim=1).item()
+        loss = output[:, class_idx].sum()
+        loss.backward()
+        weights = self.gradients.mean(dim=(2, 3), keepdim=True)
+        cam = (weights * self.activations).sum(dim=1)
+        cam = torch.relu(cam)
+        cam = torch.nn.functional.interpolate(cam.unsqueeze(1), size=input_tensor.shape[-2:], mode='bilinear', align_corners=False)
+        cam = cam.squeeze().cpu().numpy()
+        cam = (cam - cam.min()) / (cam.max() - cam.min() + 1e-8)
+        return cam
+
+def overlay_cam(img, cam, out_file):
+    plt.figure(figsize=(6, 6))
+    plt.imshow(img)
+    plt.imshow(cam, cmap='jet', alpha=0.5)
+    plt.axis('off')
+    plt.tight_layout()
+    plt.savefig(out_file)
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--image', required=True, help='path to image')
+    parser.add_argument('--weights', default='model/model.pth', help='model weights')
+    parser.add_argument('--device', default='cuda' if torch.cuda.is_available() else 'cpu')
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    model = AIModel('efficientnet-b2', num_classes=400).to(device)
+    model.load_state_dict(torch.load(args.weights, map_location=device))
+    cam_extractor = GradCAM(model, model.cbam)
+
+    img = Image.open(args.image).convert('RGB')
+    transform = data_transforms['test']
+    tensor = transform(img).unsqueeze(0).to(device)
+
+    cam = cam_extractor(tensor)
+    overlay_cam(np.array(img), cam, 'grad_cam.png')
+
+if __name__ == '__main__':
+    main()

--- a/visualize_proposals.py
+++ b/visualize_proposals.py
@@ -1,46 +1,68 @@
 import argparse
+import os
 import torch
 from PIL import Image, ImageDraw
 from model import AIModel
 from config import data_transforms
 
-
-def draw_boxes(img, boxes, out_file):
+def draw_boxes(img, boxes, out_path):
     draw = ImageDraw.Draw(img)
     for box in boxes:
-        draw.rectangle(box, outline='red', width=2)
-    img.save(out_file)
-
+        x1, y1, x2, y2 = box
+        x1, x2 = sorted([x1, x2])
+        y1, y2 = sorted([y1, y2])
+        draw.rectangle((x1, y1, x2, y2), outline='red', width=2)
+    img.save(out_path)
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--image', required=True, help='path to image')
+    parser.add_argument('--input_dir', default='data/WebFG-400/train/000', help='input image folder')
+    parser.add_argument('--output_dir', default='data/proposals', help='output folder')
     parser.add_argument('--weights', default='model/model.pth')
     parser.add_argument('--device', default='cuda' if torch.cuda.is_available() else 'cpu')
     parser.add_argument('--topk', type=int, default=5, help='number of proposals to visualize')
     args = parser.parse_args()
 
+    os.makedirs(args.output_dir, exist_ok=True)
     device = torch.device(args.device)
+
     model = AIModel('efficientnet-b2', num_classes=400).to(device)
     model.load_state_dict(torch.load(args.weights, map_location=device))
+    model.eval()
 
-    img = Image.open(args.image).convert('RGB')
     transform = data_transforms['test']
-    tensor = transform(img).unsqueeze(0).to(device)
 
-    with torch.no_grad():
-        _, boxes = model(tensor, return_boxes=True)
+    for fname in os.listdir(args.input_dir):
+        if not fname.lower().endswith(('.jpg', '.jpeg', '.png', '.bmp')):
+            continue
 
-    boxes = boxes[0][:args.topk].cpu().numpy()
-    # scale boxes to original image size
-    feat_h, feat_w = model.backbone.extract_features(tensor).shape[-2:]
-    scale_x = img.width / feat_w
-    scale_y = img.height / feat_h
-    scaled_boxes = []
-    for x1, y1, x2, y2 in boxes:
-        scaled_boxes.append((x1*scale_x, y1*scale_y, x2*scale_x, y2*scale_y))
+        img_path = os.path.join(args.input_dir, fname)
+        out_path = os.path.join(args.output_dir, fname)
 
-    draw_boxes(img, scaled_boxes, 'proposals.png')
+        try:
+            img = Image.open(img_path).convert('RGB')
+        except Exception as e:
+            print(f"[跳过] 无法读取图像 {fname}: {e}")
+            continue
+
+        tensor = transform(img).unsqueeze(0).to(device)
+
+        with torch.no_grad():
+            _, boxes = model(tensor, return_boxes=True)
+
+        boxes = boxes[0][:args.topk].cpu().numpy()
+
+        # 获取特征图尺寸以便缩放 proposal 回原图尺寸
+        feat_h, feat_w = model.backbone.extract_features(tensor).shape[-2:]
+        scale_x = img.width / feat_w
+        scale_y = img.height / feat_h
+
+        scaled_boxes = []
+        for x1, y1, x2, y2 in boxes:
+            scaled_boxes.append((x1 * scale_x, y1 * scale_y, x2 * scale_x, y2 * scale_y))
+
+        draw_boxes(img, scaled_boxes, out_path)
+        print(f"[保存] {out_path}")
 
 if __name__ == '__main__':
     main()

--- a/visualize_proposals.py
+++ b/visualize_proposals.py
@@ -1,0 +1,46 @@
+import argparse
+import torch
+from PIL import Image, ImageDraw
+from model import AIModel
+from config import data_transforms
+
+
+def draw_boxes(img, boxes, out_file):
+    draw = ImageDraw.Draw(img)
+    for box in boxes:
+        draw.rectangle(box, outline='red', width=2)
+    img.save(out_file)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--image', required=True, help='path to image')
+    parser.add_argument('--weights', default='model/model.pth')
+    parser.add_argument('--device', default='cuda' if torch.cuda.is_available() else 'cpu')
+    parser.add_argument('--topk', type=int, default=5, help='number of proposals to visualize')
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    model = AIModel('efficientnet-b2', num_classes=400).to(device)
+    model.load_state_dict(torch.load(args.weights, map_location=device))
+
+    img = Image.open(args.image).convert('RGB')
+    transform = data_transforms['test']
+    tensor = transform(img).unsqueeze(0).to(device)
+
+    with torch.no_grad():
+        _, boxes = model(tensor, return_boxes=True)
+
+    boxes = boxes[0][:args.topk].cpu().numpy()
+    # scale boxes to original image size
+    feat_h, feat_w = model.backbone.extract_features(tensor).shape[-2:]
+    scale_x = img.width / feat_w
+    scale_y = img.height / feat_h
+    scaled_boxes = []
+    for x1, y1, x2, y2 in boxes:
+        scaled_boxes.append((x1*scale_x, y1*scale_y, x2*scale_x, y2*scale_y))
+
+    draw_boxes(img, scaled_boxes, 'proposals.png')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add option to log metrics with TensorBoard and progress bars
- expose proposal boxes from the model for visualization
- add Grad-CAM and proposal visualization scripts
- document new features in README

## Testing
- `python -m py_compile *.py`
- `flake8 *.py` *(fails: numerous style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6863a444c6ac8322a2313468d744fb55