### PR TITLE
Add CBAM visualizer and simplify model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fine Grained Recognition (PyTorch)
 
-This project contains a PyTorch implementation for fine grained recognition. Besides the previous SR-GNN baseline, it now provides a ResNet50 based model enhanced with a CBAM attention module. During training, a live Matplotlib window displays losses, accuracies and attention maps.
+This project contains a PyTorch implementation for fine-grained recognition using a ResNet50 backbone enhanced with a CBAM attention module. During training, a live Matplotlib window displays losses, accuracies and attention maps.
 
 ## Setup
 Create an environment and install the dependencies:
@@ -30,6 +30,10 @@ Run training from the project root:
 python ./script/main.py dataset_dir ./datasets/Cars nb_classes 196 epochs 150 model_name cbam_resnet
 ```
 Running the command will open a Matplotlib window that updates after each epoch with the latest loss curves, accuracies and attention maps.
-```
 All configuration parameters can be changed in `config.yaml` or overridden via the command line.
 
+## Visualizing Attention
+To visualise the spatial attention produced by a trained model on a single image, run:
+```bash
+python ./script/visualize_attention.py path/to/model.pth path/to/image.jpg
+```

--- a/README.txt
+++ b/README.txt
@@ -4,5 +4,8 @@ conda activate fg_env
 pip install -r requirements.txt
 
 ####################### Training #####################
-python ./script/main.py dataset_dir ./datasets/Cars nb_classes 196 epochs 150 model_name srgnn
+python ./script/main.py dataset_dir ./datasets/Cars nb_classes 196 epochs 150 model_name cbam_resnet
+
+#################### Visualization ###################
+python ./script/visualize_attention.py path/to/model.pth path/to/image.jpg
 

--- a/script/main.py
+++ b/script/main.py
@@ -31,7 +31,6 @@ def main():
     dataset_dir  = param['DATA']['dataset_dir']
     batch_size   = param['MODEL']['batch_size']
     lr           = param['MODEL']['learning_rate']
-    model_name   = param['MODEL']['model_name']
     epochs       = param['TRAIN']['epochs']
 
     # Override from command line
@@ -99,22 +98,12 @@ def main():
     )
 
     # ---------------- Model setup ----------------
-    if model_name == 'cbam_resnet':
-        backbone = param['MODEL'].get('backbone', 'resnet50')
-        model = construct_model(
-            name=model_name,
-            backbone=backbone,
-            nb_classes=nb_classes
-        )
-    else:
-        model = construct_model(
-            name=model_name,
-            pool_size=7,
-            ROIS_resolution=42,
-            ROIS_grid_size=3,
-            minSize=2,
-            nb_classes=nb_classes,
-        )
+    backbone = param['MODEL'].get('backbone', 'resnet50')
+    model = construct_model(
+        name='cbam_resnet',
+        backbone=backbone,
+        nb_classes=nb_classes
+    )
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model.to(device)
 

--- a/script/models.py
+++ b/script/models.py
@@ -1,47 +1,11 @@
-import numpy as np
 import torch
 from torch import nn
 import torch.nn.functional as F
 import timm
 
-from RoiPoolingConvTF2 import RoiPooling
-from SelfAttention import SelfAttention
 from cbam import CBAM
-from utils import getROIS, crop, squeezefunc, stackfunc
 
 
-class SR_GNN(nn.Module):
-    """Simplified SR-GNN model implemented in PyTorch."""
-
-    def __init__(self, pool_size=7, ROIS_resolution=42, ROIS_grid_size=3, minSize=2, nb_classes=1000):
-        super().__init__()
-        self.base = timm.create_model('xception', pretrained=True, features_only=True)
-        self.base_channels = self.base.feature_info[-1]['num_chs']
-        self.rois = getROIS(resolution=ROIS_resolution, gridSize=ROIS_grid_size, minSize=minSize)
-        self.roi_pool = RoiPooling(pool_size, self.rois)
-        feat_dim = self.base_channels
-        self.attention = SelfAttention(self.base_channels)
-        self.fc = nn.Linear(feat_dim, nb_classes)
-
-    def forward(self, x):
-        features = self.base(x)[-1]  # [B, C, H, W]
-        resized = F.interpolate(
-            features,
-            size=(self.roi_pool.pool_size * 2, self.roi_pool.pool_size * 2),
-            mode='bilinear', align_corners=False
-        )
-        rois = self.roi_pool(resized)  # [B, N_rois, C, H, W]
-
-        attn_outputs = []
-        for i in range(rois.size(1)):
-            roi = rois[:, i, :, :, :]  # [B, C, H, W]
-            attn_roi = self.attention(roi)  # [B, C, H, W]
-            pooled = F.adaptive_avg_pool2d(attn_roi, 1).squeeze(-1).squeeze(-1)  # [B, C]
-            attn_outputs.append(pooled)
-
-        attn = torch.stack(attn_outputs, dim=1).mean(dim=1)  # [B, C]
-        out = self.fc(attn)  # [B, nb_classes]
-        return out
 
 
 class CBAMResNet(nn.Module):
@@ -63,8 +27,6 @@ class CBAMResNet(nn.Module):
 
 
 def construct_model(name, **kwargs):
-    if name == 'srgnn':
-        return SR_GNN(**kwargs)
     if name == 'cbam_resnet':
         backbone = kwargs.pop('backbone', 'resnet50')
         return CBAMResNet(backbone=backbone, **kwargs)

--- a/script/visualize_attention.py
+++ b/script/visualize_attention.py
@@ -1,30 +1,15 @@
 import argparse
+import os
 import cv2
 import numpy as np
 from PIL import Image
 import torch
 from torchvision import transforms
-import matplotlib.pyplot as plt
 
 from models import CBAMResNet
 
-
-def visualize(model_path, image_path, backbone='resnet50', nb_classes=1000):
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    model = CBAMResNet(backbone=backbone, nb_classes=nb_classes)
-    state_dict = torch.load(model_path, map_location=device)
-    model.load_state_dict(state_dict, strict=False)
-    model.to(device)
-    model.eval()
-
-    transform = transforms.Compose([
-        transforms.Resize((224, 224)),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                             std=[0.229, 0.224, 0.225])
-    ])
-
-    img = Image.open(image_path).convert('RGB')
+def compute_overlay(model, img_path, transform, device):
+    img = Image.open(img_path).convert('RGB')
     inp = transform(img).unsqueeze(0).to(device)
 
     with torch.no_grad():
@@ -36,32 +21,71 @@ def visualize(model_path, image_path, backbone='resnet50', nb_classes=1000):
     heatmap = cv2.applyColorMap(np.uint8(attn_norm * 255), cv2.COLORMAP_JET)
     heatmap = cv2.cvtColor(heatmap, cv2.COLOR_BGR2RGB)
     overlay = (np.array(img) * 0.5 + heatmap * 0.5).astype(np.uint8)
+    return overlay
 
-    plt.figure(figsize=(8, 4))
-    plt.subplot(1, 2, 1)
-    plt.imshow(img)
-    plt.axis('off')
-    plt.title('Input')
 
-    plt.subplot(1, 2, 2)
-    plt.imshow(overlay)
-    plt.axis('off')
-    plt.title('CBAM Attention')
-    plt.tight_layout()
-    plt.show()
+def visualize(model_path, image_folder, backbone='resnet50', nb_classes=1000):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = CBAMResNet(backbone=backbone, nb_classes=nb_classes)
+    state_dict = torch.load(model_path, map_location=device)
+    model.load_state_dict(state_dict, strict=False)
+    model.to(device)
+    model.eval()
+
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+    ])
+
+    if os.path.isdir(image_folder):
+        files = sorted([f for f in os.listdir(image_folder)
+                        if f.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp'))])
+        image_paths = [os.path.join(image_folder, f) for f in files]
+    else:
+        image_paths = [image_folder]
+
+    idx = 0
+    total = len(image_paths)
+    window_name = 'CBAM Attention'
+    cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
+
+    print("浏览键: n/右箭头 = 下一张, p/左箭头 = 上一张, Esc = 退出")
+    while True:
+        path = image_paths[idx]
+        overlay = compute_overlay(model, path, transform, device)
+
+        cv2.imshow(window_name, overlay)
+        print(f"显示 ({idx+1}/{total}): {path}")
+        key = cv2.waitKey(0)
+        # 退出
+        if key == 27:
+            break
+        # 下一张: 'n' 或 83(右箭头)
+        elif key & 0xFF == ord('n') or key == 83:
+            idx = (idx + 1) % total
+        # 上一张: 'p' 或 81(左箭头)
+        elif key & 0xFF == ord('p') or key == 81:
+            idx = (idx - 1) % total
+        else:
+            print(f"按键 {key} 未绑定，使用 n/p 或左右箭头")
+
+    cv2.destroyAllWindows()
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Visualize CBAM attention')
-    parser.add_argument('model_path', help='Path to trained model (.pth)')
-    parser.add_argument('image_path', help='Path to input image')
-    parser.add_argument('--backbone', default='resnet50', help='ResNet backbone')
-    parser.add_argument('--nb_classes', type=int, default=1000,
-                        help='Number of classes for model')
+    parser = argparse.ArgumentParser(description='浏览 CBAM 注意力热图')
+    parser.add_argument('--model_path', default='best_checkpoints/best_epoch186_acc0.8717.pth',
+                        help='CBAMResNet 检查点路径')
+    parser.add_argument('--image_folder', default='../data/small/train/000',
+                        help='单张图片路径或图片文件夹')
+    parser.add_argument('--backbone', default='resnet50', help='ResNet 骨干网络')
+    parser.add_argument('--nb_classes', type=int, default=400,
+                        help='模型类别数（与 checkpoint 一致）')
     args = parser.parse_args()
-    visualize(args.model_path, args.image_path,
-              backbone=args.backbone, nb_classes=args.nb_classes)
 
+    visualize(args.model_path, args.image_folder,
+              backbone=args.backbone, nb_classes=args.nb_classes)
 
 if __name__ == '__main__':
     main()

--- a/script/visualize_attention.py
+++ b/script/visualize_attention.py
@@ -1,0 +1,67 @@
+import argparse
+import cv2
+import numpy as np
+from PIL import Image
+import torch
+from torchvision import transforms
+import matplotlib.pyplot as plt
+
+from models import CBAMResNet
+
+
+def visualize(model_path, image_path, backbone='resnet50', nb_classes=1000):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = CBAMResNet(backbone=backbone, nb_classes=nb_classes)
+    state_dict = torch.load(model_path, map_location=device)
+    model.load_state_dict(state_dict, strict=False)
+    model.to(device)
+    model.eval()
+
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                             std=[0.229, 0.224, 0.225])
+    ])
+
+    img = Image.open(image_path).convert('RGB')
+    inp = transform(img).unsqueeze(0).to(device)
+
+    with torch.no_grad():
+        _ = model(inp)
+        attn = model.cbam.sa_weight[0, 0].detach().cpu().numpy()
+
+    attn = cv2.resize(attn, img.size)
+    attn_norm = (attn - attn.min()) / (attn.max() - attn.min() + 1e-8)
+    heatmap = cv2.applyColorMap(np.uint8(attn_norm * 255), cv2.COLORMAP_JET)
+    heatmap = cv2.cvtColor(heatmap, cv2.COLOR_BGR2RGB)
+    overlay = (np.array(img) * 0.5 + heatmap * 0.5).astype(np.uint8)
+
+    plt.figure(figsize=(8, 4))
+    plt.subplot(1, 2, 1)
+    plt.imshow(img)
+    plt.axis('off')
+    plt.title('Input')
+
+    plt.subplot(1, 2, 2)
+    plt.imshow(overlay)
+    plt.axis('off')
+    plt.title('CBAM Attention')
+    plt.tight_layout()
+    plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Visualize CBAM attention')
+    parser.add_argument('model_path', help='Path to trained model (.pth)')
+    parser.add_argument('image_path', help='Path to input image')
+    parser.add_argument('--backbone', default='resnet50', help='ResNet backbone')
+    parser.add_argument('--nb_classes', type=int, default=1000,
+                        help='Number of classes for model')
+    args = parser.parse_args()
+    visualize(args.model_path, args.image_path,
+              backbone=args.backbone, nb_classes=args.nb_classes)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- remove ROI pooling and self-attention code
- keep only the CBAM-ResNet model
- simplify training script to always build CBAM ResNet
- add a script to visualize CBAM attention for a single image
- update documentation for new workflow

## Testing
- `python -m py_compile script/*.py`
- `pip install opencv-python-headless`
- `python script/visualize_attention.py dummy.pth dummy.jpg --nb_classes 10` *(fails to display due to headless environment but runs without errors)*

------
https://chatgpt.com/codex/tasks/task_e_68830720ba148322a090e983975af059