### PR TITLE
Fix CBAM attention visualization

### DIFF
--- a/script/visualize_attention.py
+++ b/script/visualize_attention.py
@@ -29,14 +29,19 @@ def visualize(model_path, image_folder, backbone='resnet50', nb_classes=1000):
     model = CBAMResNet(backbone=backbone, nb_classes=nb_classes)
     state_dict = torch.load(model_path, map_location=device)
 
-    # Ensure checkpoint was trained with CBAM or attention maps will be random
-    if not any(k.startswith("cbam") for k in state_dict.keys()):
+    # ---- Validate checkpoint ----
+    keys = list(state_dict.keys())
+    has_cbam = any('cbam.sa' in k or 'cbam.ca' in k for k in keys)
+    if not has_cbam:
         raise ValueError(
             f"Checkpoint '{model_path}' does not contain CBAM weights. "
-            "Load a model trained with CBAM to visualize attention correctly."
+            "Load a checkpoint trained with CBAM to visualize attention correctly."
         )
 
-    model.load_state_dict(state_dict, strict=False)
+    # Handle DataParallel checkpoints
+    state_dict = {k.replace('module.', ''): v for k, v in state_dict.items()}
+
+    model.load_state_dict(state_dict, strict=True)
     model.to(device)
     model.eval()
 

--- a/script/visualize_attention.py
+++ b/script/visualize_attention.py
@@ -28,6 +28,14 @@ def visualize(model_path, image_folder, backbone='resnet50', nb_classes=1000):
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = CBAMResNet(backbone=backbone, nb_classes=nb_classes)
     state_dict = torch.load(model_path, map_location=device)
+
+    # Ensure checkpoint was trained with CBAM or attention maps will be random
+    if not any(k.startswith("cbam") for k in state_dict.keys()):
+        raise ValueError(
+            f"Checkpoint '{model_path}' does not contain CBAM weights. "
+            "Load a model trained with CBAM to visualize attention correctly."
+        )
+
     model.load_state_dict(state_dict, strict=False)
     model.to(device)
     model.eval()


### PR DESCRIPTION
## Summary
- validate that the checkpoint used by `visualize_attention.py` actually contains CBAM weights
- stop silent loading of plain ResNet checkpoints which produces meaningless attention maps

## Testing
- `python -m py_compile script/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68831203b9e88322b8ca39476ad82d04